### PR TITLE
Fix search not working via HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ remote_theme: just-the-docs/just-the-docs
 title: Beemo Docs
 email: hello@beemo.gg
 description: Beemo is a free antispam Discord Bot that can stop userbot raids against your server.
+url: https://docs.beemo.gg
 
 aux_links:
   beemo.gg:


### PR DESCRIPTION
Fixes this error by explicitly setting the site url:
![](https://im-a-dolphin.de/s/127619d.png)

As suggested in https://github.com/just-the-docs/just-the-docs/issues/845#issuecomment-1175562529

While that option doesn't seem to be documented too well, it is used in the example config: https://github.com/just-the-docs/just-the-docs/blob/a45b328c7a6d97163157d38b1332c47f84792f14/_config.yml#L19